### PR TITLE
Generated method does not binding this

### DIFF
--- a/lib/method.tpl
+++ b/lib/method.tpl
@@ -1,7 +1,7 @@
 /**
  * <%= description %>
  */
-<%= name %>(<%= args.map(a => a.key + ': ' + a.flow).join(', ') %>): Promise<{body: <%= responseFlow %>, headers: Object, status: number}> {
+<%= name %> = (<%= args.map(a => a.key + ': ' + a.flow).join(', ') %>): Promise<{body: <%= responseFlow %>, headers: Object, status: number}> => {
   const tpl = uriTemplates('<%= href %>');
   const path = tpl.fill({<%= hrefArgs.map(a => a.key + ': ' + a.key).join(', ') %>});
   let opts = options || {};


### PR DESCRIPTION
Generated method does not binding `this`.
So, can't access the `simple-api-client` methods.

I changed it to bind `this`, so check it.

**Now**

```js
export default class APIClient extends SimpleAPIClient {
  userCreate() {
    ...
    this.post(path, opts);  // this.post is undefined
  }
}
```

**Fixed**

```js
export default class APIClient extends SimpleAPIClient {
  userCreate = () => {
    ...
    this.post(path, opts);  // LGTM
  }
}
```


cc @moqada